### PR TITLE
Remove need for password file from univention-app install.

### DIFF
--- a/roles/setup/tasks/apps.yml
+++ b/roles/setup/tasks/apps.yml
@@ -1,10 +1,4 @@
 ---
-- name: generate admin password file
-  template:
-    src: "templates/temppasswd.j2"
-    dest: "/tmp/univention"
-  tags: apps
-
 - name: update univention apps
   shell:
     cmd: "/usr/bin/univention-app update"
@@ -12,7 +6,7 @@
 
 - name: install apps from appstore
   shell:
-    cmd: "/usr/bin/univention-app install {{ item }} --username Administrator --noninteractive --pwdfile /tmp/univention"
+    cmd: "/usr/bin/univention-app install {{ item }} --username Administrator --noninteractive --pwdfile <({{ rootpassword }})"
   loop:
     - letsencrypt
     - etherpad-lite

--- a/templates/temppasswd.j2
+++ b/templates/temppasswd.j2
@@ -1,1 +1,0 @@
-{{ rootpassword }}


### PR DESCRIPTION
By using a bash build in feature we can remove the need to create a password file explicitly, that can be forgotten to be deleted. Since the ansible module shell runs a bash instance on the target UCS, i propose we use a bash feature to let it create the necessary password file only for the runtime of the programm.