### PR TITLE
Add missing - to fix the udm syntax

### DIFF
--- a/roles/setup/tasks/create-users.yml
+++ b/roles/setup/tasks/create-users.yml
@@ -14,7 +14,7 @@
     --set school=schule \
     --set ucsschoolRole=teacher:school:schule \
     --set ucsschoolRole=school_admin:school:schule \
-    --append option=ucsschoolTeacher \
-    --append option=ucsschoolAdministrator"
+    --append-option=ucsschoolTeacher \
+    --append-option=ucsschoolAdministrator"
   tags:
     - create-users


### PR DESCRIPTION
UDM requires `--append-option` instead of `--append option`

This may soon be replaced by the ansible UDM-Module to avoid non-idempotent shell execution